### PR TITLE
Fixturize shell didn't write null and numeric values correctly.

### DIFF
--- a/cakephp/shells/fixturize/fixturize.php
+++ b/cakephp/shells/fixturize/fixturize.php
@@ -75,7 +75,13 @@ class FixturizeShell extends Shell{
 					$record[$name]['id'] = String::uuid();
 				}
 				foreach ($record[$name] as $field => $val) {
-					$out[] = sprintf('			\'%s\' => \'%s\',', addcslashes($field, "'"), addcslashes($val, "'"));
+					if (is_null($val)) {
+						$out[] = sprintf('			\'%s\' => null,', addcslashes($field, "'"));
+					} else if (is_numeric($val)) {
+						$out[] = sprintf('			\'%s\' => %s,', addcslashes($field, "'"), $val);
+					} else {
+						$out[] = sprintf('			\'%s\' => \'%s\',', addcslashes($field, "'"), addcslashes($val, "'"));
+					}
 				}
 				$out[] = '		),';
 			}


### PR DESCRIPTION
Where there was a null in the DB the fixturize shell writes '' into the fixture which will then be loaded as empty string into the DB but not as null-value....
